### PR TITLE
fix big sur b3 paths

### DIFF
--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -22,35 +22,41 @@ launch_daemon_plist_name='com.erikng.installapplications'
 launch_agent_base_path='Library/LaunchAgents/'
 launch_daemon_base_path='Library/LaunchDaemons/'
 
-# Load agent if installing to a running system
+# Run the rest of this script only on a running OS
 if [[ $3 == "/" ]] ; then
-  # Fail the install if the admin forgets to change their paths and they don't exist.
-  if [ ! -e "$3${launch_daemon_base_path}${launch_daemon_plist_name}.plist" ] || [ ! -e "$3${launch_agent_base_path}${launch_agent_plist_name}.plist" ]; then
-    echo "LaunchAgent or Daemon missing, exiting"
-    exit 1
-  fi
+  base_path=$3
+elif [[ $3 == "/System/Volumes/Data" ]] ; then
+  base_path="$3/"
+else
+  exit 0
+fi
 
-  # Attempt to unload the daemon if it's stuck in memory but gone from disk
-  /bin/launchctl list | /usr/bin/grep 'installapplications'
-  if [[ $? -eq 0 ]] && [[ ! -e "$3${launch_daemon_base_path}${launch_daemon_plist_name}.plist" ]]; then
-    /bin/launchctl remove "${launch_daemon_plist_name}"
-  fi
+# Fail the install if the admin forgets to change their paths and they don't exist.
+if [ ! -e "$base_path${launch_daemon_base_path}${launch_daemon_plist_name}.plist" ] || [ ! -e "$base_path${launch_agent_base_path}${launch_agent_plist_name}.plist" ]; then
+  echo "LaunchAgent or Daemon missing, exiting"
+  exit 1
+fi
 
-  # Enable the LaunchDaemon
-  /bin/launchctl load "$3${launch_daemon_base_path}${launch_daemon_plist_name}.plist"
+# Attempt to unload the daemon if it's stuck in memory but gone from disk
+/bin/launchctl list | /usr/bin/grep 'installapplications'
+if [[ $? -eq 0 ]] && [[ ! -e "$base_path${launch_daemon_base_path}${launch_daemon_plist_name}.plist" ]]; then
+  /bin/launchctl remove "${launch_daemon_plist_name}"
+fi
 
-  # Current console user information
-  console_user=$(/usr/bin/stat -f "%Su" /dev/console)
-  console_user_uid=$(/usr/bin/id -u "$console_user")
+# Enable the LaunchDaemon
+/bin/launchctl load "$base_path${launch_daemon_base_path}${launch_daemon_plist_name}.plist"
 
-  # Only enable the LaunchAgent if there is a user logged in, otherwise rely on built in LaunchAgent behavior
-  if [[ -z "$console_user" ]]; then
-    echo "Did not detect user"
-  elif [[ "$console_user" == "loginwindow" ]]; then
-    echo "Detected Loginwindow Environment"
-  elif [[ "$console_user" == "_mbsetupuser" ]]; then
-    echo "Detect SetupAssistant Environment"
-  else
-    /bin/launchctl asuser "${console_user_uid}" /bin/launchctl load "$3${launch_agent_base_path}${launch_agent_plist_name}.plist"
-  fi
+# Current console user information
+console_user=$(/usr/bin/stat -f "%Su" /dev/console)
+console_user_uid=$(/usr/bin/id -u "$console_user")
+
+# Only enable the LaunchAgent if there is a user logged in, otherwise rely on built in LaunchAgent behavior
+if [[ -z "$console_user" ]]; then
+  echo "Did not detect user"
+elif [[ "$console_user" == "loginwindow" ]]; then
+  echo "Detected Loginwindow Environment"
+elif [[ "$console_user" == "_mbsetupuser" ]]; then
+  echo "Detect SetupAssistant Environment"
+else
+  /bin/launchctl asuser "${console_user_uid}" /bin/launchctl load "$base_path${launch_agent_base_path}${launch_agent_plist_name}.plist"
 fi

--- a/scripts/preinstall
+++ b/scripts/preinstall
@@ -22,30 +22,35 @@ launch_daemon_plist_name='com.erikng.installapplications'
 launch_agent_base_path='Library/LaunchAgents/'
 launch_daemon_base_path='Library/LaunchDaemons/'
 
+# Run the rest of this script only on a running OS
 if [[ $3 == "/" ]] ; then
-  # Current console user information
-  console_user=$(/usr/bin/stat -f "%Su" /dev/console)
-  console_user_uid=$(/usr/bin/id -u "$console_user")
-
-  # Attempt to unload the daemon if it's stuck in memory but gone from disk
-  /bin/launchctl list | /usr/bin/grep 'installapplications'
-  if [[ $? -eq 0 ]] && [[ ! -e "$3${launch_daemon_base_path}${launch_daemon_plist_name}.plist" ]]; then
-    /bin/launchctl remove "${launch_daemon_plist_name}"
-  fi
-
-  if [[ -z "$console_user" ]]; then
-    echo "Did not detect user"
-  elif [[ "$console_user" == "loginwindow" ]]; then
-    echo "Detected Loginwindow Environment"
-  elif [[ "$console_user" == "_mbsetupuser" ]]; then
-    echo "Detect SetupAssistant Environment"
-  else
-    # Attempt to unload the agent if it's stuck in memory but gone from disk
-    /bin/launchctl asuser "${console_user_uid}" /bin/launchctl list | /usr/bin/grep 'installapplications'
-    if [[ $? -eq 0 ]] && [[ ! -e "$3${launch_agent_base_path}${launch_agent_plist_name}.plist" ]]; then
-      /bin/launchctl asuser "${console_user_uid}" /bin/launchctl remove "${launch_agent_plist_name}"
-    fi
-  fi
+  base_path=$3
+elif [[ $3 == "/System/Volumes/Data" ]] ; then
+  base_path="$3/"
+else
+  exit 0
 fi
 
-exit 0
+# Current console user information
+console_user=$(/usr/bin/stat -f "%Su" /dev/console)
+console_user_uid=$(/usr/bin/id -u "$console_user")
+
+# Attempt to unload the daemon if it's stuck in memory but gone from disk
+/bin/launchctl list | /usr/bin/grep 'installapplications'
+if [[ $? -eq 0 ]] && [[ ! -e "$base_path${launch_daemon_base_path}${launch_daemon_plist_name}.plist" ]]; then
+  /bin/launchctl remove "${launch_daemon_plist_name}"
+fi
+
+if [[ -z "$console_user" ]]; then
+  echo "Did not detect user"
+elif [[ "$console_user" == "loginwindow" ]]; then
+  echo "Detected Loginwindow Environment"
+elif [[ "$console_user" == "_mbsetupuser" ]]; then
+  echo "Detect SetupAssistant Environment"
+else
+  # Attempt to unload the agent if it's stuck in memory but gone from disk
+  /bin/launchctl asuser "${console_user_uid}" /bin/launchctl list | /usr/bin/grep 'installapplications'
+  if [[ $? -eq 0 ]] && [[ ! -e "$base_path${launch_agent_base_path}${launch_agent_plist_name}.plist" ]]; then
+    /bin/launchctl asuser "${console_user_uid}" /bin/launchctl remove "${launch_agent_plist_name}"
+  fi
+fi


### PR DESCRIPTION
When installing a package via MDM on Big Sur, the behavior of arguments are different:

A manual install will show something like this for $0/$1/$2/$3

```
/tmp/PKInstallSandbox.l3yeSQ/Scripts/com.uber.pkg.mdm.OffRLT/postinstall
/Users/erikg/Desktop/mdmtest-1.0.pkg
/
/
```

whereas a MDM installation will show something like this:

```
/Library/InstallerSandboxes/.PKInstallSandboxManager/16D65155-E119-4290-913D-9C772D60D921.activeSandbox/Scripts/com.uber.pkg.mdm.Wp0Zrx/postinstall
/var/folders/zz/zyxvpxvq6csfxvn_n0000044000011/C/com.apple.appstore/9ABF6C5F-1FA8-41FE-B73D-1435E3B7A4A0/b58ebfa3-3f2c-48db-97a7-6994164585d7.pkg
/System/Volumes/Data
/System/Volumes/Data
```

This means that for the launch agents and daemons, the path could be:

`/Library/LaunchAgents` and `/Library/LaunchDaemons` pre beta 3 

post beta 3 `/System/Volumes/Data/Library/LaunchAgents` and `/System/Volumes/Data/Library/LaunchDaemons`