### PR TITLE
Add HTTP redirect option

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ In the LaunchDaemon add the following:
 ```
 
 #### Follow HTTP Redirects
-If you need to redirect InstallApplictions to fetch content from another URL, pass `--follow-redirects` in your LaunchDaemon. Useful for situations when content may be stored on a CDN and/or if your webserver returns pre-signed URLs for the object.
+If your webserver needs to redirect InstallApplictions to fetch content from another URL, pass `--follow-redirects` in your LaunchDaemon. Useful for situations where content may be stored on a CDN or object storage.
 
 ```xml
 <string>--follow-redirects</string>

--- a/README.md
+++ b/README.md
@@ -192,6 +192,13 @@ In the LaunchDaemon add the following:
 <string>Basic dGVzdDp0ZXN0</string>
 ```
 
+#### Follow HTTP Redirects
+If you need to redirect InstallApplictions to fetch content from another URL, pass `--follow-redirects` in your LaunchDaemon. Useful for situations when content may be stored on a CDN and/or if your webserver returns pre-signed URLs for the object.
+
+```xml
+<string>--follow-redirects</string>
+```
+
 ### DEPNotify
 InstallApplications can work in conjunction with DEPNotify to automatically create and manipulate the progress bar.
 

--- a/payload/Library/installapplications/installapplications.py
+++ b/payload/Library/installapplications/installapplications.py
@@ -280,6 +280,9 @@ def download_if_needed(item, stage, type, opts, depnotifystatus):
         if opts.headers:
             item.update({'additional_headers':
                          {'Authorization': opts.headers}})
+        # Check if we need to follow redirects.
+        if opts.follow_redirects:
+            item.update({'follow_redirects': True})
         # Download the file once:
         iaslog('Starting download: %s' % (urllib.parse.unquote(itemurl)))
         if opts.depnotify:
@@ -404,6 +407,9 @@ def main():
     o.add_option('--userscript', default=None,
                  help=('Optional: Trigger a user script run.'),
                  action='store_true')
+    o.add_option('--follow-redirects', default=False,
+                 help=('Optional: Follow HTTP redirects.'),
+                 action='store_true')
 
     opts, args = o.parse_args()
 
@@ -516,6 +522,10 @@ def main():
     if opts.headers:
         headers = {'Authorization': opts.headers}
         json_data.update({'additional_headers': headers})
+
+    # Check if we need to follow redirects.
+    if opts.follow_redirects:
+        item.update({'follow_redirects': True})
 
     # Delete the bootstrap file if it exists, to ensure it's up to date.
     if not opts.skip_validation:


### PR DESCRIPTION
Follow up to https://github.com/macadmins/installapplications/issues/76

Introduces `--follow-redirects` argument option to InstallApplications.

If this flag is passed, InstallApplications will follow redirects from the web server to the remote URL. By default, InstallApplications will not follow redirects. Thus, existing implementations _should_ be unaffected by this feature addition.

I made an update to the README for this change. Let me know if anything else is needed.
