### PR TITLE
for Apple Silicon, install Rosetta 2 during preinstall

### DIFF
--- a/scripts/preinstall
+++ b/scripts/preinstall
@@ -56,6 +56,6 @@ else
 fi
 
 # Install Rosetta 2 if running on Apple Silicon
-if [[ $(/usr/sbin/sysctl machdep.cpu.brand_string) =~ "Apple" ]]; then
-  echo "A" | /usr/sbin/softwareupdate --install-rosetta
+if [[ $(/usr/bin/arch) == "arm64" ]]; then
+  /usr/sbin/softwareupdate --install-rosetta --agree-to-license
 fi

--- a/scripts/preinstall
+++ b/scripts/preinstall
@@ -54,3 +54,8 @@ else
     /bin/launchctl asuser "${console_user_uid}" /bin/launchctl remove "${launch_agent_plist_name}"
   fi
 fi
+
+# Install Rosetta 2 if running on Apple Silicon
+if [[ $(/usr/sbin/sysctl machdep.cpu.brand_string) =~ "Apple" ]]; then
+  echo "A" | /usr/sbin/softwareupdate --install-rosetta
+fi


### PR DESCRIPTION
Not the most elegant idea, but it seems to work.