### PR TITLE
Handle equals sign in item metadata

### DIFF
--- a/generatejson.py
+++ b/generatejson.py
@@ -125,7 +125,7 @@ def main():
     for item in args.item:
         processedItem = {}
         for itemOption in item:
-            values = itemOption.split('=')
+            values = itemOption.split('=', 1)
             processedItem[values[0]] = values[1]
         itemsToProcess.append(processedItem)
 


### PR DESCRIPTION
When calling `split()` while parsing each item's metadata limit the splits to 1.

This fixes the case where URLs include an equals sign, but also applies to all other metadata types.  It likely won't make a difference for any others, but conceivably could apply to `item-path` (and would similarly fix a path with an equals sign).