### PR TITLE
add support for skipping packages depending on arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ The JSON structure is quite simple. You supply the following:
 - version of package (to check package receipts)
 - package id (to check for package receipts)
 - type of item (currently `rootscript`, `package` or `userscript`)
+- skip_if criteria to skip a pkg (currently `x86_64`, `intel`, `arm64` or `apple_silicon`)
 
 The following is an example JSON:
 ```json
@@ -263,6 +264,7 @@ The following is an example JSON:
       "version": "1.0",
       "hash": "sha256 hash",
       "name": "Stage 1 Package Name",
+      "skip_if": "x86_64",
       "type": "package"
     },
     {

--- a/generatejson.py
+++ b/generatejson.py
@@ -9,6 +9,7 @@
 # item-type='A type' \
 # item-url='A url' \
 # script-do-not-wait='A boolean' \
+# pkg-skip-if='A string' \
 # --base-url URL \
 # --output PATH
 
@@ -105,10 +106,11 @@ def main():
                         help='Base URL to where root dir is hosted')
     parser.add_argument('--output', default=None, action='store',
                         help='Required: Output directory to save json')
-    parser.add_argument('--item', default=None, action='append', nargs=6,
+    parser.add_argument('--item', default=None, action='append', nargs=7,
                         metavar=(
                             'item-name', 'item-path', 'item-stage',
-                            'item-type', 'item-url', 'script-do-not-wait'),
+                            'item-type', 'item-url', 'script-do-not-wait',
+                            'pkg-skip-if'),
                         help='Required: Options for item. All items are \
                         required. Scripts default to rootscript and stage \
                         Scripts default to rootscript and stage defaults to userland')
@@ -221,6 +223,14 @@ def main():
                 'installapplications/%s' % fileName
             itemJson['packageid'] = pkgId
             itemJson['version'] = pkgVersion
+            try:
+                if item['pkg-skip-if'] not in ('false', 'False', '0'):
+                    # Add the key to the item
+                    if item['pkg-skip-if'] in ('intel', 'x86_64',
+                                            'apple_silicon', 'arm64'):
+                        itemJson['skip_if'] = item['pkg-skip-if']
+            except:
+                pass
 
         # Append the info to the appropriate stage
         stages[itemStage].append(itemJson)


### PR DESCRIPTION
Tested with adding this to bootstrap.json:

```
    {
      "file": "/Library/installapplications/chef-17.3.48-1.x86_64.pkg",
      "hash": "de5f090b0d6ca1a1804a1790739412a05d9a2e0365db7b21aecb7b6ebff253c3",
      "name": "chef_intel_pkg",
      "packageid": "com.getchef.pkg.chef",
      "skip_if": "arm64",
      "type": "package",
      "url": "https://url.to.repo/chef-17.3.48-1.x86_64.pkg",
      "version": "17.3.48"
    },
    {
      "file": "/Library/installapplications/chef-17.3.48-1.arm64.pkg",
      "hash": "35489a2d4616fd978b49e524f30bdf1b2615c0fb30bb9222766f8b48faee1d80",
      "name": "chef_arm_pkg",
      "packageid": "com.getchef.pkg.chef",
      "skip_if": "x86_64",
      "type": "package",
      "url": "https://url.to.repo/chef-17.3.48-1.arm64.pkg",
      "version": "17.3.48"
    },
```

Used updated InstallApplications package and it successfully installed the packages and skipped the ones marked:

On intel it skipped the arm one
```
2021-08-13 10:44:13.500 Python[2240:33808] [InstallApplications] Skipping chef_intel_pkg - passes skip_if criteria: arm64
```

On arm it skipped the intel one
```
2021-08-13 10:44:21.939 Python[18761:121744] [InstallApplications] Skipping chef_arm_pkg - passes skip_if criteria: x86_64
```