### PR TITLE
Move the main loop that processes itemsToProcess to a function

### DIFF
--- a/generatejson.py
+++ b/generatejson.py
@@ -31,11 +31,11 @@ from xml.dom import minidom
 def gethash(filename):
     hash_function = hashlib.sha256()
     if not os.path.isfile(filename):
-        return "FILE NOT FOUND - CHECK YOUR PATH"
+        return 'FILE NOT FOUND - CHECK YOUR PATH'
 
-    fileref = open(filename, "rb")
+    fileref = open(filename, 'rb')
     while 1:
-        chunk = fileref.read(2 ** 16)
+        chunk = fileref.read(2**16)
         if not chunk:
             break
         hash_function.update(chunk)
@@ -44,24 +44,26 @@ def gethash(filename):
 
 
 def getpkginfopath(filename):
-    """Extracts the package BOM with xar"""
-    cmd = ["/usr/bin/xar", "-tf", filename]
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    '''Extracts the package BOM with xar'''
+    cmd = ['/usr/bin/xar', '-tf', filename]
+    proc = subprocess.Popen(cmd,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
     (bom, err) = proc.communicate()
-    bom = bom.strip().split(b"\n")
+    bom = bom.strip().split(b'\n')
     if proc.returncode == 0:
         for entry in bom:
-            if entry.startswith(b"PackageInfo"):
+            if entry.startswith(b'PackageInfo'):
                 return entry
-            elif entry.endswith(b".pkg/PackageInfo"):
+            elif entry.endswith(b'.pkg/PackageInfo'):
                 return entry
     else:
         print("Error: %s while extracting BOM for %s" % (err, filename))
 
 
 def extractpkginfo(filename):
-    """Takes input of a file path and returns a file path to the
-    extracted PackageInfo file."""
+    '''Takes input of a file path and returns a file path to the
+    extracted PackageInfo file.'''
     cwd = os.getcwd()
 
     if not os.path.isfile(filename):
@@ -70,64 +72,176 @@ def extractpkginfo(filename):
         tmpFolder = tempfile.mkdtemp()
         os.chdir(tmpFolder)
         # need to get path from BOM
-        pkgInfoPath = getpkginfopath(filename).decode("utf-8")
+        pkgInfoPath = getpkginfopath(filename).decode('utf-8')
 
         extractedPkgInfoPath = os.path.join(tmpFolder, pkgInfoPath)
-        cmd = ["/usr/bin/xar", "-xf", filename, pkgInfoPath]
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        cmd = ['/usr/bin/xar', '-xf', filename, pkgInfoPath]
+        proc = subprocess.Popen(cmd,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
         out, err = proc.communicate()
         os.chdir(cwd)
         return extractedPkgInfoPath
 
 
 def getpkginfo(filename):
-    """Takes input of a file path and returns strings of the
-    package identifier and version from PackageInfo."""
+    '''Takes input of a file path and returns strings of the
+    package identifier and version from PackageInfo.'''
     if not os.path.isfile(filename):
         return "", ""
 
     else:
         pkgInfoPath = extractpkginfo(os.path.abspath(filename))
         dom = minidom.parse(pkgInfoPath)
-        pkgRefs = dom.getElementsByTagName("pkg-info")
+        pkgRefs = dom.getElementsByTagName('pkg-info')
         for ref in pkgRefs:
-            pkgId = ref.attributes["identifier"].value
-            pkgVersion = ref.attributes["version"].value
+            pkgId = ref.attributes['identifier'].value
+            pkgVersion = ref.attributes['version'].value
             return pkgId, pkgVersion
+
+
+def build_item_dict(itemsToProcess, base_url):
+    '''Takes a dict of item and the base_url where root dir is hosted
+    itemsToProcess = [
+        {
+            'item-name': '',
+            'item-path': '',
+            'item-stage': '',
+            'item-type': '',
+            'item-url': '',
+            'script-do-not-wait': '',
+            'pkg-skip-if': ''
+        },
+        ...
+    ]
+
+    returns a dict that can be dumped to bootstrap.json'''
+
+    # Create our stages now so InstallApplications won't blow up
+    stages = {
+        'preflight': [],
+        'setupassistant': [],
+        'userland': []
+    }
+
+    # Process each item in the order they were passed in
+    for item in itemsToProcess:
+        itemJson = {}
+
+        # Get the file extension of the file
+        fileExt = os.path.splitext(item['item-path'])[1]
+        # Get the file name of the file
+        fileName = os.path.basename(item['item-path'])
+        # Get the full path of the file
+        filePath = item['item-path']
+
+        # Determine the type of item to process - for scripts, default to
+        # rootscript
+        if fileExt in ('.py', '.sh', '.rb', '.php'):
+            try:
+                itemJson['type'] = itemType = item['item-type']
+            except KeyError:
+                itemJson['type'] = itemType = 'rootscript'
+        elif fileExt == '.pkg':
+            itemJson['type'] = itemType = 'package'
+        else:
+            print('Could not determine package type for item or unsupported: \
+            %s' % str(item))
+            exit(1)
+        if itemType not in ('package', 'rootscript', 'userscript'):
+            print('item-type malformed: %s' % str(item['item-type']))
+            exit(1)
+
+        # Determine the stage of the item to process - default to userland
+        try:
+            if item['item-stage'] in ('preflight', 'setupassistant',
+                                      'userland'):
+                itemStage = item['item-stage']
+                pass
+            else:
+                print('item-stage malformed: %s' % str(item['item-stage']))
+                exit(1)
+        except KeyError:
+            itemStage = 'userland'
+
+        # Determine the url of the item to process - defaults to
+        # baseurl/stage/filename
+        try:
+            itemJson['url'] = item['item-url']
+        except KeyError:
+            itemJson['url'] = '%s/%s/%s' % (base_url, itemStage, fileName)
+
+        # Determine the name of the item to process - defaults to the filename
+        if not item['item-name']:
+            itemJson['name'] = fileName
+        else:
+            itemJson['name'] = item['item-name']
+
+        # Determine the hash of the item to process - SHA256
+        itemJson['hash'] = gethash(filePath)
+
+        # Add information for scripts and packages
+        if itemType in ('rootscript', 'userscript'):
+            if itemType == 'userscript':
+                # Pass the userscripts folder path
+                itemJson['file'] = '/Library/'\
+                    'installapplications/userscripts/%s' % fileName
+            else:
+                itemJson['file'] = '/Library/'\
+                    'installapplications/%s' % fileName
+            # Check crappy way of doing booleans
+            try:
+                if item['script-do-not-wait'] in ('true', 'True', '1',
+                                                  'false', 'False', '0'):
+                    # If True, pass the key to the item
+                    if item['script-do-not-wait'] in ('true', 'True', '1'):
+                        itemJson['donotwait'] = True
+                else:
+                    print(
+                        'script-do-not-wait malformed: %s ' %
+                        str(item['script-do-not-wait'])
+                    )
+                    exit(1)
+            except:
+                itemJson['donotwait'] = False
+
+        # If packages, we need the version and packageid
+        elif itemType == 'package':
+            (pkgId, pkgVersion) = getpkginfo(filePath)
+            itemJson['file'] = '/Library/'\
+                'installapplications/%s' % fileName
+            itemJson['packageid'] = pkgId
+            itemJson['version'] = pkgVersion
+            try:
+                # handle skipping based on architecture
+                if item['pkg-skip-if'] not in ('false', 'False', '0'):
+                    # Add the key to the item
+                    if item['pkg-skip-if'] in ('intel', 'x86_64',
+                                               'apple_silicon', 'arm64'):
+                        itemJson['skip_if'] = item['pkg-skip-if']
+            except:
+                pass
+
+        # Append the info to the appropriate stage
+        stages[itemStage].append(itemJson)
+
+    return stages
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--base-url",
-        default=None,
-        action="store",
-        help="Base URL to where root dir is hosted",
-    )
-    parser.add_argument(
-        "--output",
-        default=None,
-        action="store",
-        help="Required: Output directory to save json",
-    )
-    parser.add_argument(
-        "--item",
-        default=None,
-        action="append",
-        nargs=7,
-        metavar=(
-            "item-name",
-            "item-path",
-            "item-stage",
-            "item-type",
-            "item-url",
-            "script-do-not-wait",
-            "pkg-skip-if",
-        ),
-        help="Required: Options for item. All items are \
+    parser.add_argument('--base-url', default=None, action='store',
+                        help='Base URL to where root dir is hosted')
+    parser.add_argument('--output', default=None, action='store',
+                        help='Required: Output directory to save json')
+    parser.add_argument('--item', default=None, action='append', nargs=6,
+                        metavar=(
+                            'item-name', 'item-path', 'item-stage',
+                            'item-type', 'item-url', 'script-do-not-wait',
+                            'pkg-skip-if'),
+                        help='Required: Options for item. All items are \
                         required. Scripts default to rootscript and stage \
-                        Scripts default to rootscript and stage defaults to userland",
-    )
+                        Scripts default to rootscript and stage defaults to userland')
     args = parser.parse_args()
 
     # Bail if we don't have one item, the base url and the output dir
@@ -141,140 +255,27 @@ def main():
     for item in args.item:
         processedItem = {}
         for itemOption in item:
-            values = itemOption.split("=", 1)
+            values = itemOption.split('=', 1)
             processedItem[values[0]] = values[1]
         itemsToProcess.append(processedItem)
 
     # Create our stages now so InstallApplications won't blow up
-    stages = {"preflight": [], "setupassistant": [], "userland": []}
-
-    # Process each item in the order they were passed in
-    for item in itemsToProcess:
-        itemJson = {}
-        # Get the file extension of the file
-        fileExt = os.path.splitext(item["item-path"])[1]
-        # Get the file name of the file
-        fileName = os.path.basename(item["item-path"])
-        # Get the full path of the file
-        filePath = item["item-path"]
-
-        # Determine the type of item to process - for scripts, default to
-        # rootscript
-        if fileExt in (".py", ".sh", ".rb", ".php"):
-            try:
-                itemJson["type"] = itemType = item["item-type"]
-            except KeyError:
-                itemJson["type"] = itemType = "rootscript"
-        elif fileExt == ".pkg":
-            itemJson["type"] = itemType = "package"
-        else:
-            print(
-                "Could not determine package type for item or unsupported: \
-            %s"
-                % str(item)
-            )
-            exit(1)
-        if itemType not in ("package", "rootscript", "userscript"):
-            print("item-type malformed: %s" % str(item["item-type"]))
-            exit(1)
-
-        # Determine the stage of the item to process - default to userland
-        try:
-            if item["item-stage"] in ("preflight", "setupassistant", "userland"):
-                itemStage = item["item-stage"]
-                pass
-            else:
-                print("item-stage malformed: %s" % str(item["item-stage"]))
-                exit(1)
-        except KeyError:
-            itemStage = "userland"
-
-        # Determine the url of the item to process - defaults to
-        # baseurl/stage/filename
-        try:
-            itemJson["url"] = item["item-url"]
-        except KeyError:
-            itemJson["url"] = "%s/%s/%s" % (args.base_url, itemStage, fileName)
-
-        # Determine the name of the item to process - defaults to the filename
-        if not item["item-name"]:
-            itemJson["name"] = fileName
-        else:
-            itemJson["name"] = item["item-name"]
-
-        # Determine the hash of the item to process - SHA256
-        itemJson["hash"] = gethash(filePath)
-
-        # Add information for scripts and packages
-        if itemType in ("rootscript", "userscript"):
-            if itemType == "userscript":
-                # Pass the userscripts folder path
-                itemJson["file"] = (
-                    "/Library/" "installapplications/userscripts/%s" % fileName
-                )
-            else:
-                itemJson["file"] = "/Library/" "installapplications/%s" % fileName
-            # Check crappy way of doing booleans
-            try:
-                if item["script-do-not-wait"] in (
-                    "true",
-                    "True",
-                    "1",
-                    "false",
-                    "False",
-                    "0",
-                ):
-                    # If True, pass the key to the item
-                    if item["script-do-not-wait"] in ("true", "True", "1"):
-                        itemJson["donotwait"] = True
-                else:
-                    print(
-                        "script-do-not-wait malformed: %s "
-                        % str(item["script-do-not-wait"])
-                    )
-                    exit(1)
-            except:
-                itemJson["donotwait"] = False
-
-        # If packages, we need the version and packageid
-        elif itemType == "package":
-            (pkgId, pkgVersion) = getpkginfo(filePath)
-            itemJson["file"] = "/Library/" "installapplications/%s" % fileName
-            itemJson["packageid"] = pkgId
-            itemJson["version"] = pkgVersion
-            try:
-                if item["pkg-skip-if"] not in ("false", "False", "0"):
-                    # Add the key to the item
-                    if item["pkg-skip-if"] in (
-                        "intel",
-                        "x86_64",
-                        "apple_silicon",
-                        "arm64",
-                    ):
-                        itemJson["skip_if"] = item["pkg-skip-if"]
-            except:
-                pass
-
-        # Append the info to the appropriate stage
-        stages[itemStage].append(itemJson)
+    stages = build_item_dict(itemsToProcess=itemsToProcess, base_url=args.base_url)
 
     # Saving the json file to the output directory path
-    if args.output:
-        savePath = os.path.join(args.output, "bootstrap.json")
-    else:
-        savePath = os.path.join(rootdir, "bootstrap.json")
+    savePath = os.path.join(args.output, 'bootstrap.json')
 
     # Sort the primary keys, but not the sub keys, so things are in the correct
     # order
     try:
-        with open(savePath, "w") as outFile:
+        with open(savePath, 'w') as outFile:
             json.dump(stages, outFile, sort_keys=True, indent=2)
     except IOError:
-        print("[Error] Not a valid directory: %s" % savePath)
+        print('[Error] Not a valid directory: %s' % savePath)
         exit(1)
 
-    print("Json saved to %s" % savePath)
+    print('Json saved to %s' % savePath)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
Move the main loop that processes itemsToProcess (after parsing CLI args)
and construction of stages dict out to a function.

The function takes only the itemsToProcess list that is
constructed by parsing the args.item inputs as well as the base-url.

Within the function the code is essentially unchanged, and the
function returns the completed stages dictionary.

The only other change is to remove the branch "if args.output" when
constructing the savePath...args.output is required, so it will always
be set (also, the alternative 'rootdir' appears to not be defined).

This version is updated to handle the newly added `pkg-skip-if` settings.