### PR TITLE
Set middleware_file to NoneType to address UnboundLocalError

### DIFF
--- a/payload/Library/installapplications/installapplications.py
+++ b/payload/Library/installapplications/installapplications.py
@@ -170,6 +170,7 @@ def process_request_options(options):
     Taken from:
     https://github.com/munki/munki/blob/main/code/client/munkilib/fetch.py
     """
+    middleware_file = None
     ia_dir = os.path.realpath(os.path.dirname(sys.argv[0]))
     for name in os.listdir(ia_dir):
         if name.startswith('middleware'):


### PR DESCRIPTION
Per feedback in MacAdmins Slack - https://macadmins.slack.com/archives/C54N3AT2B/p1632169234064000 - the `process_request_options()` function stack traces with an `UnboundLocalError`.

Ex:
```
2021-09-20 15:21:16.357 Python[1680:22582] [InstallApplications] Beginning InstallApplications run
2021-09-20 15:21:16.357 Python[1680:22582] [InstallApplications] InstallApplications path: /Library/installapplications
2021-09-20 15:21:16.357 Python[1680:22582] [InstallApplications] InstallApplications LaunchDaemon path: /Library/LaunchDaemons/com.erikng.installapplications.plist
2021-09-20 15:21:16.357 Python[1680:22582] [InstallApplications] InstallApplications LaunchAgent path: /Library/LaunchAgents/com.erikng.installapplications.plist
2021-09-20 15:21:16.357 Python[1680:22582] [InstallApplications] InstallApplications json path: /Library/installapplications/bootstrap.json
2021-09-20 15:21:16.358 Python[1680:22582] [InstallApplications] Starting download: https://serverinfo/bootstrap.json
Traceback (most recent call last):
  File "/Library/installapplications/installapplications.py", line 710, in <module>
    main()
  File "/Library/installapplications/installapplications.py", line 592, in main
    downloadfile(json_data)
  File "/Library/installapplications/installapplications.py", line 186, in downloadfile
    options = process_request_options(options)
  File "/Library/installapplications/installapplications.py", line 177, in process_request_options
    if middleware_file:
UnboundLocalError: local variable 'middleware_file' referenced before assignment
```

This change sets the `middleware_file` variable to `None` at the beginning of the function and avoids the error.



**Basic Tests:**

```
$: python
Python 3.8.2 (default, Jun 14 2020, 21:28:42)
[Clang 11.0.0 (clang-1100.0.33.8)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> import sys

# setup function in python
>>> def process_request_options(options):
...   middleware_file = None
...   ia_dir = os.path.realpath(os.path.dirname(sys.argv[0]))
...   for name in os.listdir(ia_dir):
...     if name.startswith('middleware'):
...       middleware_file = os.path.splitext(name)[0]
...   if middleware_file:
...     globals()['middleware'] = __import__(middleware_file, fromlist=[middleware_file])
...     options = middleware.process_request_options(options)
...   return options
...

# setup function input data
>>> json_data = {"url": "https://foobar.url", "file": "/foo/bar/path/", "name": "Bootstrap.json"}

# pass into process_request_options():
>>> test = process_request_options(json_data)
>>> test
{'url': 'https://foobar.url', 'file': '/foo/bar/path/', 'name': 'Bootstrap.json'}


# Now, add a middlware.py file underneath project path
>>> ia_dir = os.path.realpath(os.path.dirname(sys.argv[0]))
>>> ia_dir
'/Users/bfreezy/workspace/installapplications/payload/Library/installapplications'

# contents of middleware.py
"""
$: cat /Users/bfreezy/workspace/installapplications/payload/Library/installapplications/middleware.py
def process_request_options(options):
   print(f"***Requesting: {options.get('url')}")
   return options
"""

# call same function, only this time we have middleware
>>> test = process_request_options(json_data)
***Requesting: https://foobar.url
>>> test
{'url': 'https://foobar.url', 'file': '/foo/bar/path/', 'name': 'Bootstrap.json'}
```

