### PR TITLE
Update for M1

### DIFF
--- a/build_python_framework
+++ b/build_python_framework
@@ -8,7 +8,7 @@
 
 TOOLSDIR=$(dirname $0)
 REQUIREMENTS="${TOOLSDIR}/py3_requirements.txt"
-MACOS_VERSION=11.0 # use 10.9 for non-universal
+MACOS_VERSION=10.9 # use 10.9 for non-universal, 11.0 for universal
 PYTHON_BIN_VERSION=3.9
 PYTHON_VERSION=3.9.1
 PYTHON_PRERELEASE_VERSION=
@@ -76,7 +76,6 @@ if [[ "${XCODE_SELECT}" != "/Applications/Xcode.app/Contents/Developer" ]]; then
     echo "Building the universal python framework may result in errors due to Xcode not being installed"
 fi
 "${PYTHONTOOLDIR}/make_relocatable_python_framework.py" \
-    --baseurl "${PYTHON_BASEURL}" \
     --python-version "${PYTHON_VERSION}" \
     --os-version "${MACOS_VERSION}" \
     --pip-requirements "${REQUIREMENTS}" \

--- a/generatejson.py
+++ b/generatejson.py
@@ -234,7 +234,7 @@ def main():
                         help='Base URL to where root dir is hosted')
     parser.add_argument('--output', default=None, action='store',
                         help='Required: Output directory to save json')
-    parser.add_argument('--item', default=None, action='append', nargs=6,
+    parser.add_argument('--item', default=None, action='append', nargs=7,
                         metavar=(
                             'item-name', 'item-path', 'item-stage',
                             'item-type', 'item-url', 'script-do-not-wait',

--- a/py3_requirements.txt
+++ b/py3_requirements.txt
@@ -1,6 +1,4 @@
 cffi==1.14.4
---no-binary cffi
 pycparser==2.20
 pyobjc==7.0.1
 xattr==0.9.7
---no-binary xattr


### PR DESCRIPTION
These are the changes I had to make to run on M1.  Feel free to take or leave any of them.

1. In build_python_framework use 10.9 build of python to have an all intel build.  Pyobjc did not have an M1 build that I could see.
2. In generatejson.py another argument was added in an earlier commit.
3. In py3_requirements.txt build all binaries, otherwise I got missing dependencies and a broken python.