### PR TITLE
Update checkreceipt function for python3

### DIFF
--- a/payload/Library/installapplications/installapplications.py
+++ b/payload/Library/installapplications/installapplications.py
@@ -131,7 +131,7 @@ def checkreceipt(packageid):
         output = proc.communicate()
         receiptout = output[0]
         if receiptout:
-            plist = plistlib.readPlistFromString(receiptout)
+            plist = plistlib.loads(receiptout)
             version = plist["pkg-version"]
         else:
             version = "0.0.0.0.0"


### PR DESCRIPTION
The `checkreceipt` function is using a python2 method of `readPlistFromString`. This results in the below exception being raised:

```
AttributeError: module plistlib has no attribute readPlistFromString
```

This results in InstallApplications always returning `0.0.0.0.0` for the `pkg-version`, thereby re-installing applications already installed. The fix for this is to replace `readPlistFromString` with `loads`.

```
import subprocess
import plistlib

packageid = com.getchef.pkg.chef

def checkreceipt(packageid):
    try:
        cmd = ["/usr/sbin/pkgutil", "--pkg-info-plist", packageid]
        proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
        output = proc.communicate()
        receiptout = output[0]
        if receiptout:
            plist = plistlib.loads(receiptout)
            version = plist["pkg-version"]
        else:
            version = "0.0.0.0.0"
        return version
    except Exception:
        version = "0.0.0.0.0"
        return version
```

```
checkreceipt(packageid)
17.10.3
```