### PR TITLE
Add a `print` statement to the file not found in the `gethash` function

### DIFF
--- a/generatejson.py
+++ b/generatejson.py
@@ -31,6 +31,7 @@ from xml.dom import minidom
 def gethash(filename):
     hash_function = hashlib.sha256()
     if not os.path.isfile(filename):
+        print('FILE NOT FOUND - CHECK YOUR PATH')
         return 'FILE NOT FOUND - CHECK YOUR PATH'
 
     fileref = open(filename, 'rb')


### PR DESCRIPTION
Add a print to the file not found in the get hash function so you can see it when you run generatejson.py on the command line and also pick it up in automation