### PR TITLE
Add configuration for item retries and wait intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ You can pass an unlimited amount of `--item` arguments, each one with the follow
 * item-type - required, generatejson will detect package vs script. Scripts default to rootscript, so pass "userscript" to this variable if your item is a userscript.
 * item-url - required, if --base-url is set generatejson will auto-generate the URL as base-url/stage/item-file-name. You can override this automatic generation by passing a URL to the item here.
 * script-do-not-wait - required, only applies to userscript and rootscript item-types. Defaults to false.
+* retries - optional, integer value that defaults to 3 if not specified
+* retrywait - optional, integer value that defaults to 5 if not specified
 
 Run the tool:
 
@@ -391,6 +393,8 @@ item-stage='setupassistant' \
 item-type='package' \
 item-url='https://github.com/setupassistant/package.pkg' \
 script-do-not-wait=False \
+retries=5 \
+retrywait=10 \
 --item \
 item-name='userland user script' \
 item-path='/localpath/userscript.py' \

--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ The JSON structure is quite simple. You supply the following:
 - package id (to check for package receipts)
 - type of item (currently `rootscript`, `package` or `userscript`)
 - skip_if criteria to skip a pkg (currently `x86_64`, `intel`, `arm64` or `apple_silicon`)
+- retries is the number of times an item is retried to download (defaults to 3 if not set)
+- retrywait is the number of seconds to wait before attempting a retry to download (defaults to 5 if not set)
 
 The following is an example JSON:
 
@@ -305,7 +307,9 @@ The following is an example JSON:
       "hash": "sha256 hash",
       "name": "Example Preflight Script",
       "type": "rootscript",
-      "url": "https://domain.tld/preflight_script.py"
+      "url": "https://domain.tld/preflight_script.py",
+      "retries": 5,
+      "retrywait": 10
     }
   ],
   "setupassistant": [
@@ -316,7 +320,9 @@ The following is an example JSON:
       "version": "1.0",
       "hash": "sha256 hash",
       "name": "setupassistant Package Name",
-      "type": "package"
+      "type": "package",
+      "retries": 5,
+      "retrywait": 10
     }
   ],
   "userland": [
@@ -328,7 +334,9 @@ The following is an example JSON:
       "hash": "sha256 hash",
       "name": "Stage 1 Package Name",
       "skip_if": "x86_64",
-      "type": "package"
+      "type": "package",
+      "retries": 5,
+      "retrywait": 10
     },
     {
       "file": "/Library/installapplications/userland_examplerootscript.py",

--- a/generatejson.py
+++ b/generatejson.py
@@ -234,7 +234,7 @@ def main():
                         help='Base URL to where root dir is hosted')
     parser.add_argument('--output', default=None, action='store',
                         help='Required: Output directory to save json')
-    parser.add_argument('--item', default=None, action='append', nargs=6,
+    parser.add_argument('--item', default=None, action='append', nargs=7,
                         metavar=(
                             'item-name', 'item-path', 'item-stage',
                             'item-type', 'item-url', 'script-do-not-wait',

--- a/generatejson.py
+++ b/generatejson.py
@@ -10,6 +10,8 @@
 # item-url='A url' \
 # script-do-not-wait='A boolean' \
 # pkg-skip-if='A string' \
+# retries='An integer' \
+# retrywait='An integer' \
 # --base-url URL \
 # --output PATH
 
@@ -111,7 +113,9 @@ def build_item_dict(itemsToProcess, base_url):
             'item-type': '',
             'item-url': '',
             'script-do-not-wait': '',
-            'pkg-skip-if': ''
+            'pkg-skip-if': '',
+            'retries': int,
+            'retrywait': int
         },
         ...
     ]
@@ -239,7 +243,7 @@ def main():
                         metavar=(
                             'item-name', 'item-path', 'item-stage',
                             'item-type', 'item-url', 'script-do-not-wait',
-                            'pkg-skip-if'),
+                            'pkg-skip-if', 'retries', 'retrywait'),
                         help='Required: Options for item. All items are \
                         required. Scripts default to rootscript and stage \
                         Scripts default to rootscript and stage defaults to userland')

--- a/payload/Library/installapplications/installapplications.py
+++ b/payload/Library/installapplications/installapplications.py
@@ -613,7 +613,7 @@ def main():
     # Process all stages
     for stage in stages:
         if stage not in ias_item_runtimes_dict.keys():
-                ias_item_runtimes_dict[stage] = {}
+            ias_item_runtimes_dict[stage] = {}
         iaslog("Beginning %s" % stage)
         if stage == "preflight":
             # Ensure we actually have a preflight key in the json
@@ -650,10 +650,10 @@ def main():
                         )
                         time.sleep(1)
 
-            if type == "package":
-                # Start package item runtime timer
-                package_runtime_start = time.time()
+            # Start item runtime timer
+            item_runtime_start = time.time()
 
+            if type == "package":
                 packageid = item["packageid"]
                 version = item["version"]
                 try:
@@ -683,14 +683,7 @@ def main():
                     iaslog("Installing %s from %s" % (name, path))
                     # Install the package
                     installpackage(item["file"])
-
-                # Log package item rumtime
-                write_item_total_runtime(stage, name, package_runtime_start)
-
             elif type == "rootscript":
-                # Start rootscript item runtime timer
-                rootscript_runtime_start = time.time()
-
                 if "url" in item:
                     download_if_needed(item, stage, type, opts)
                 iaslog("Starting root script: %s" % path)
@@ -709,14 +702,7 @@ def main():
                         continue
 
                 runrootscript(path, donotwait)
-
-                # Log rootscript item rumtime
-                write_item_total_runtime(stage, name, rootscript_runtime_start)
-
             elif type == "userscript":
-                # Start userscript item runtime timer
-                userscript_runtime_start = time.time()
-
                 if "url" in item:
                     download_if_needed(item, stage, type, opts)
                 if stage == "setupassistant":
@@ -733,9 +719,8 @@ def main():
                     iaslog("Waiting for user script to complete: %s" % path)
                     time.sleep(0.5)
 
-                # Log userscript item rumtime
-                write_item_total_runtime(stage, name, userscript_runtime_start)
-
+            # Log item runtime
+            write_item_total_runtime(stage, name, item_runtime_start)
     # Cleanup and send good exit status
     cleanup(0)
 

--- a/payload/Library/installapplications/installapplications.py
+++ b/payload/Library/installapplications/installapplications.py
@@ -131,7 +131,7 @@ def checkreceipt(packageid):
         output = proc.communicate()
         receiptout = output[0]
         if receiptout:
-            plist = plistlib.readPlistFromString(receiptout)
+            plist = plistlib.loads(receiptout)
             version = plist["pkg-version"]
         else:
             version = "0.0.0.0.0"

--- a/payload/Library/installapplications/installapplications.py
+++ b/payload/Library/installapplications/installapplications.py
@@ -637,11 +637,12 @@ def main():
             # Set number or retries, and wait interval between retries
             try:
                 retries = item["retries"]
-                retrywait = item["retrywait"]
             except KeyError as e:
                 retries = 3
+            try:
+                retrywait = item["retrywait"]
+            except KeyError as e:
                 retrywait = 5
-                continue
             iaslog("%s processing %s %s at %s" % (stage, type, name, path))
             # On userland stage, we want to wait until we are actually
             # in the user's session.


### PR DESCRIPTION
InstallApplications (IAs) has a hardcoded download retry limit of 3 retries. This prevents an adminitrator from defining or having control over the number of times an item is attempted to download. This PR gives an administrator the option to define the number of retries, and the number of seconds to wait in between retries. If the item is missing the `retries` or `retrywait` values, then IAs will default to `3` retries, with a retry wait time of `5` seconds between retries.

Outside of this PR, something I noticed was that the hardcoded retries was happening very rapidly (~100ths of seconds). This is because the `while` block starting on L355 doesn't have some kind of `time.sleep()` invocation to delay the retry attempts. This led to items failing very fast. The use case I am using IAs is with Mac laptops, that can take several seconds to join WiFi or otherwise get network functioning. So, when `userland` items begin to take off, and the Mac is still trying to get full functioning WiFi, IAs basically gives up since the retry failures are so quick.

I'm hoping this PR, if merged, gives administrators the ability to improve IAs item success.