### PR TITLE
generatejson: update nargs count

### DIFF
--- a/generatejson.py
+++ b/generatejson.py
@@ -239,7 +239,7 @@ def main():
                         help='Base URL to where root dir is hosted')
     parser.add_argument('--output', default=None, action='store',
                         help='Required: Output directory to save json')
-    parser.add_argument('--item', default=None, action='append', nargs=7,
+    parser.add_argument('--item', default=None, action='append', nargs=9,
                         metavar=(
                             'item-name', 'item-path', 'item-stage',
                             'item-type', 'item-url', 'script-do-not-wait',


### PR DESCRIPTION
With the addition of retries/retrieswait, need to increment the nargs count by two else it throws the "length of metavar tuple does not match nargs" ValueError.