### PR TITLE
generatejson: write retries and retrywait to json

### DIFF
--- a/generatejson.py
+++ b/generatejson.py
@@ -227,6 +227,11 @@ def build_item_dict(itemsToProcess, base_url):
             except:
                 pass
 
+        # Add retries and retry wait if they're set
+        if item['retries'] is not None:
+            itemJson['retries'] = item['retries']
+        if item['retrywait'] is not None:
+            itemJson['retrywait'] = item['retrywait']
         # Append the info to the appropriate stage
         stages[itemStage].append(itemJson)
 


### PR DESCRIPTION
The initial implementation added argparse handling, but did not actually write out the retries and retrywait values to the JSON blob. This change adds a simple "is not None" test and writes them out if it passes.