### PR TITLE
generatejson - cast retries and retrywait to ints

### DIFF
--- a/generatejson.py
+++ b/generatejson.py
@@ -227,11 +227,12 @@ def build_item_dict(itemsToProcess, base_url):
             except:
                 pass
 
-        # Add retries and retry wait if they're set
+        # Add retries and retry wait if they're set. Cast to int because
+        # argparse defaults to these being strings.
         if item['retries'] is not None:
-            itemJson['retries'] = item['retries']
+            itemJson['retries'] = int(item['retries'])
         if item['retrywait'] is not None:
-            itemJson['retrywait'] = item['retrywait']
+            itemJson['retrywait'] = int(item['retrywait'])
         # Append the info to the appropriate stage
         stages[itemStage].append(itemJson)
 


### PR DESCRIPTION
By default, argparse is using str for the retries and retrywait. This change forces a cast to int so that we don't end up with strings being read into IAs itself (throws a TypeError when it hits the retries code path).

Ideally I'd have argparse validate this and just store it as an int, but with using nargs I can't find an elegant way to do that without a lot of refactoring and I don't think that's worth it.