### PR TITLE
Update preinstall with new launchagent label

### DIFF
--- a/scripts/preinstall
+++ b/scripts/preinstall
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # If you change your daemon and agent file names, update the following two lines
-launch_agent_plist_name='com.erikng.installapplications'
+launch_agent_plist_name='com.erikng.installapplications.launchagent'
 launch_daemon_plist_name='com.erikng.installapplications'
 
 # Base paths


### PR DESCRIPTION
A package made from https://github.com/macadmins/installapplications/commit/edfde096da910c4accf8637450b232ace7d668b9 will fail without this change